### PR TITLE
Make real IP logging work in proxy scenario

### DIFF
--- a/zpush/start.sh
+++ b/zpush/start.sh
@@ -26,7 +26,7 @@ else
 fi
 
 echo "Configuring Z-Push for use behind a reverse proxy"
-sed -e "s#define([\"']USE_CUSTOM_REMOTE_IP_HEADER[\"'],\s*false)#define('USE_CUSTOM_REMOTE_IP_HEADER', true)#" \
+sed -e "s#define([\"']USE_CUSTOM_REMOTE_IP_HEADER[\"'],\s*false)#define('USE_CUSTOM_REMOTE_IP_HEADER', 'HTTP_X_FORWARDED_FOR')#" \
     -i /etc/z-push/z-push.conf.php
 
 echo "Ensure config ownership"


### PR DESCRIPTION
USE_CUSTOM_REMOTE_IP_HEADER should either be false or contain the name of the header to be used.